### PR TITLE
Début du refactor

### DIFF
--- a/Backend/src/org/teamneko/schrodinger/backend/RC522/DeviceInitializationException.java
+++ b/Backend/src/org/teamneko/schrodinger/backend/RC522/DeviceInitializationException.java
@@ -1,0 +1,26 @@
+package org.teamneko.schrodinger.backend.RC522;
+
+public class DeviceInitializationException extends Exception {
+	private static final long serialVersionUID = -1465790667080873043L;
+
+	public DeviceInitializationException() {
+		super();
+	}
+
+	public DeviceInitializationException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public DeviceInitializationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public DeviceInitializationException(String message) {
+		super(message);
+	}
+
+	public DeviceInitializationException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/Backend/src/org/teamneko/schrodinger/backend/RC522/MFRC522.java
+++ b/Backend/src/org/teamneko/schrodinger/backend/RC522/MFRC522.java
@@ -3,369 +3,204 @@ package org.teamneko.schrodinger.backend.RC522;
 import com.pi4j.wiringpi.Gpio;
 import com.pi4j.wiringpi.Spi;
 
-
 public class MFRC522 {
 
-	/* 
-	Register overview, with their adress, their name (same as those in the datasheet) and a brief description
-	For further implementation details, see page 36 of the datasheet  
-	https://www.nxp.com/documents/data_sheet/MFRC522.pdf
-	*/	
-	 
-	 //Page 0: Command and status
-	 //public static final byte Reserved 		= 0x00; // reserved for future use
-	 public static final byte CommandReg 		= 0x01; // starts and stops command execution
-	 public static final byte ComlEnReg 		= 0x02; // enable and disable interrupt request control bits
-	 public static final byte DivlEnReg 		= 0x03; // enable and disable interrupt request control bits
-	 public static final byte ComIrqReg 		= 0x04; // interrupt request bits
-	 public static final byte DivIrqReg 		= 0x05; // interrupt request bits
-	 public static final byte ErrorReg 			= 0x06; // error bits showing the error status of the last command executed
-	 public static final byte Status1Reg 		= 0x07; // communication status bits
-	 public static final byte Status2Reg 		= 0x08; // receiver and transmitter status bits
-	 public static final byte FIFODataReg 		= 0x09; // input and output of 64 byte FIFO buffer
-	 public static final byte FIFOLevelReg 		= 0x0A; // number of bytes stored in the FIFO buffer
-	 public static final byte WaterLevelReg 	= 0x0B; // level for FIFO underflow and overflow warning
-	 public static final byte ControlReg 		= 0x0C; // miscellaneous control registers
-	 public static final byte BitFramingReg 	= 0x0D; // adjustments for bit-oriented frames
-	 public static final byte CollReg 			= 0x0E; // bit position of the first bit-collision detected on the RF interface
-	 //public static final byte Reserved 		= 0x0F; // reserved for future use
-	 
-	 
-	 //Page 1: Command
-	 //public static final byte Reserved 		= 0x10; // reserved for future use
-	 public static final byte ModeReg 			= 0x11; // defines general modes for transmitting and receiving
-	 public static final byte TxModeReg 		= 0x12; // defines transmission data rate and framing
-	 public static final byte RxModeReg 		= 0x13; // defines reception data rate and framing
-	 public static final byte TxControlReg 		= 0x14; // controls the logical behavior of the antenna driver pins TX1 and TX2
-	 public static final byte TxASKReg 			= 0x15; // controls the setting of the transmission modulation
-	 public static final byte TxSelReg 			= 0x16; // selects the internal sources for the antenna driver
-	 public static final byte RxSelReg 			= 0x17; // selects internal receiver settings
-	 public static final byte RxThresholdReg	= 0x18; // selects thresholds for the bit decoder
-	 public static final byte DemodReg 			= 0x19; // defines demodulator settings
-	 //public static final byte Reserved 		= 0x1A; // reserved for future use
-	 //public static final byte Reserved 		= 0x1B; // reserved for future use
-	 public static final byte MfTxReg 			= 0x1C; // controls some MIFARE communication transmit parameters
-	 public static final byte MfRxReg 			= 0x1D; // controls some MIFARE communication receive parameters
-	 //public static final byte Reserved 		= 0x1E; // reserved for future use
-	 public static final byte SerialSpeedReg	= 0x1F; // selects the speed of the serial UART interface
-	 
-	 
-	 //Page 2: Configuration
-	 //public static final byte Reserved 		= 0x20; // reserved for future use
-	 public static final byte CRCResultRegMSB 	= 0x21; // shows the MSB and LSB values of the CRC calculation
-	 public static final byte CRCResultRegLSB 	= 0x22; // shows the MSB and LSB values of the CRC calculation
-	 //public static final byte Reserved 		= 0x23; // reserved for future use
-	 public static final byte ModWidthReg 		= 0x24; // controls the ModWidth setting
-	 //public static final byte Reserved 		= 0x25; // reserved for future use
-	 public static final byte RFCfgReg 			= 0x26; // configures the receiver gain
-	 public static final byte GsNReg 			= 0x27; // selects the conductance of the antenna driver pins TX1 and TX2 for modulation
-	 public static final byte CWGsPReg 			= 0x28; // defines the conductance of the p-driver output during periods of no modulation
-	 public static final byte ModGsPReg 		= 0x29; // defines the conductance of the p-driver output during periods of modulation
-	 public static final byte TModeReg 			= 0x2A; // defines settings for the internal timer
-	 public static final byte TPrescalerReg 	= 0x2B; // defines settings for the internal timer
-	 public static final byte TReloadRegH 		= 0x2C; // defines the 16-bit timer reload value
-	 public static final byte TReloadRegL 		= 0x2D; // defines the 16-bit timer reload value
-	 public static final byte TCounterValReg1 	= 0x2E; // shows the 16-bit timer value
-	 public static final byte TCounterValReg2 	= 0x2F; // shows the 16-bit timer value
-	 
-	 //Page 3: Test register
-	 //public static final byte Reserved 		= 0x30; // reserved for future use
-	 public static final byte TestSel1Reg 		= 0x31; // general test signal configuration
-	 public static final byte TestSel2Reg 		= 0x32; // general test signal configuration and PRBS control
-	 public static final byte TestPinEnReg 		= 0x33; // enables pin output driver on pins D1 to D7
-	 public static final byte TestPinValueReg 	= 0x34; // defines the values for D1 to D7 when it is used as an I/O bus
-	 public static final byte TestBusReg 		= 0x35; // shows the status of the internal test bus
-	 public static final byte AutoTestReg 		= 0x36; // controls the digital self test
-	 public static final byte VersionReg 		= 0x37; // shows the software version
-	 public static final byte AnalogTestReg 	= 0x38; // controls the pins AUX1 and AUX2
-	 public static final byte TestDAC1Reg 		= 0x39; // defines the test value for TestDAC1
-	 public static final byte TestDAC2Reg 		= 0x3A; // defines the test value for TestDAC2
-	 public static final byte TestADCReg 		= 0x3B; // shows the value of ADC I and Q channels
-	 //public static final byte Reserved 		= 0x3C; // reserved for production tests
-	 //public static final byte Reserved 		= 0x3D; // reserved for production tests
-	 //public static final byte Reserved 		= 0x3E; // reserved for production tests
-	 //public static final byte Reserved 		= 0x3F; // reserved for production tests
-	 
-	 
-	 //Other Useful registers
-	 
-	 //RC522
-     public static final byte PCD_IDLE       	= 0x00;
-     public static final byte PCD_AUTHENT    	= 0x0E;
-     public static final byte PCD_RECEIVE    	= 0x08;
-     public static final byte PCD_TRANSMIT   	= 0x04;
-     public static final byte PCD_TRANSCEIVE 	= 0x0C;
-     public static final byte PCD_RESETPHASE 	= 0x0F;
-     public static final byte PCD_CALCCRC    	= 0x03;
+	/*
+	 * Register overview, with their adress, their name (same as those in the
+	 * datasheet) and a brief description For further implementation details,
+	 * see page 36 of the datasheet
+	 * https://www.nxp.com/documents/data_sheet/MFRC522.pdf
+	 */
 
-     //PICC
-     public  static final byte PICC_REQIDL    	= 0x26;
-     public  static final byte PICC_REQALL    	= 0x52;
-     public  static final byte PICC_ANTICOLL  	= (byte)0x93;
-     public  static final byte PICC_SElECTTAG 	= (byte)0x93;
-     public  static final byte PICC_AUTHENT1A 	= 0x60;
-     public  static final byte PICC_AUTHENT1B 	= 0x61;
-     public  static final byte PICC_READ      	= 0x30;
-     public  static final byte PICC_WRITE     	= (byte)0xA0;
-     public  static final byte PICC_DECREMENT 	= (byte)0xC0;
-     public  static final byte PICC_INCREMENT 	= (byte)0xC1;
-     public  static final byte PICC_RESTORE   	= (byte)0xC2;
-     public  static final byte PICC_TRANSFER  	= (byte)0xB0;
-     public  static final byte PICC_HALT      	= 0x50;
-	 
-	 public static final byte RESETVALUE		= 0x00;
-	 public final int MAX_LEN 					= 16;
-	 
-	 public static final int MI_OK       		= 0;
-	 public static final int MI_NOTAGERR 		= 1;
-     public static final int MI_ERR      		= 2;
-	 
-	 private int SPI_SELECT 					= 0; 	// "GPIO10" MOSI, "GPIO09" MISO
-	 private int Speed 							= 500000;
-	 private int ResetPin						= 22; 	// Enabling RST on pin 22 by default
-	 
-	 public static String currentID				= "0000000000";
-	 private boolean SPI_Initialized			= false;
-	 
-	 
-	 
-	 MFRC522()
-     {
-        MFRC522_Init();
-     }
-	
-	 MFRC522(int PinReset)
-     {
-        this.ResetPin = PinReset;
-        MFRC522_Init();
-     }
-	
-	 MFRC522(int Speed,int PinReset)
-     {
-        this.ResetPin = PinReset;
-		this.Speed = Speed;
-        MFRC522_Init();
-     }
-    
-	public void MFRC522_Init()
-    {
-		if (SPI_Initialized == false){
-			//Initialize SPI only one time
-	        Gpio.wiringPiSetup();           //Enabling wiringPi pin schema
-	        if (Spi.wiringPiSPISetup(SPI_SELECT,Speed) <= -1){
-				System.out.println(" --> Failed to set up  SPI communication");
-				return;
-	        }
-		}
+	public static final byte AnalogTestReg = 0x38; // controls the pins AUX1 and
+													// AUX2
+	public static final byte AutoTestReg = 0x36; // controls the digital self
+													// test
+	public static final byte BitFramingReg = 0x0D; // adjustments for
+													// bit-oriented frames
+	public static final byte CollReg = 0x0E; // bit position of the first
+												// bit-collision detected on the
+												// RF interface
+	// public static final byte Reserved = 0x0F; // reserved for future use
+	public static final byte ComIrqReg = 0x04; // interrupt request bits
+	public static final byte ComlEnReg = 0x02; // enable and disable interrupt
+												// request control bits
+	// Page 0: Command and status
+	// public static final byte Reserved = 0x00; // reserved for future use
+	public static final byte CommandReg = 0x01; // starts and stops command
+												// execution
+	public static final byte ControlReg = 0x0C; // miscellaneous control
+												// registers
+	public static final byte CRCResultRegLSB = 0x22; // shows the MSB and LSB
+														// values of the CRC
+														// calculation
+	// Page 2: Configuration
+	// public static final byte Reserved = 0x20; // reserved for future use
+	public static final byte CRCResultRegMSB = 0x21; // shows the MSB and LSB
+														// values of the CRC
+														// calculation
+	public static final byte CWGsPReg = 0x28; // defines the conductance of the
+												// p-driver output during
+												// periods of no modulation
+	public static final byte DemodReg = 0x19; // defines demodulator settings
+	public static final byte DivIrqReg = 0x05; // interrupt request bits
+
+	public static final byte DivlEnReg = 0x03; // enable and disable interrupt
+												// request control bits
+	public static final byte ErrorReg = 0x06; // error bits showing the error
+												// status of the last command
+												// executed
+	public static final byte FIFODataReg = 0x09; // input and output of 64 byte
+													// FIFO buffer
+	public static final byte FIFOLevelReg = 0x0A; // number of bytes stored in
+													// the FIFO buffer
+	public static final byte GsNReg = 0x27; // selects the conductance of the
+											// antenna driver pins TX1 and TX2
+											// for modulation
+	public static final byte MfRxReg = 0x1D; // controls some MIFARE
+												// communication receive
+												// parameters
+	// public static final byte Reserved = 0x1A; // reserved for future use
+	// public static final byte Reserved = 0x1B; // reserved for future use
+	public static final byte MfTxReg = 0x1C; // controls some MIFARE
+												// communication transmit
+												// parameters
+	public static final int MI_ERR = 2;
+	public static final int MI_NOTAGERR = 1;
+	public static final int MI_OK = 0;
+	// Page 1: Command
+	// public static final byte Reserved = 0x10; // reserved for future use
+	public static final byte ModeReg = 0x11; // defines general modes for
+												// transmitting and receiving
+	public static final byte ModGsPReg = 0x29; // defines the conductance of the
+												// p-driver output during
+												// periods of modulation
+
+	// public static final byte Reserved = 0x23; // reserved for future use
+	public static final byte ModWidthReg = 0x24; // controls the ModWidth
+													// setting
+	public static final byte PCD_AUTHENT = 0x0E;
+	public static final byte PCD_CALCCRC = 0x03;
+	// RC522
+	public static final byte PCD_IDLE = 0x00;
+	public static final byte PCD_RECEIVE = 0x08;
+	public static final byte PCD_RESETPHASE = 0x0F;
+	public static final byte PCD_TRANSCEIVE = 0x0C;
+	public static final byte PCD_TRANSMIT = 0x04;
+	public static final byte PICC_ANTICOLL = (byte) 0x93;
+	public static final byte PICC_AUTHENT1A = 0x60;
+	public static final byte PICC_AUTHENT1B = 0x61;
+	public static final byte PICC_DECREMENT = (byte) 0xC0;
+	public static final byte PICC_HALT = 0x50;
+
+	public static final byte PICC_INCREMENT = (byte) 0xC1;
+	public static final byte PICC_READ = 0x30;
+	public static final byte PICC_REQALL = 0x52;
+	// PICC
+	public static final byte PICC_REQIDL = 0x26;
+	public static final byte PICC_RESTORE = (byte) 0xC2;
+	public static final byte PICC_SElECTTAG = (byte) 0x93;
+	public static final byte PICC_TRANSFER = (byte) 0xB0;
+	public static final byte PICC_WRITE = (byte) 0xA0;
+	public static final byte RESETVALUE = 0x00;
+	// public static final byte Reserved = 0x25; // reserved for future use
+	public static final byte RFCfgReg = 0x26; // configures the receiver gain
+	public static final byte RxModeReg = 0x13; // defines reception data rate
+												// and framing
+
+	// Other Useful registers
+
+	public static final byte RxSelReg = 0x17; // selects internal receiver
+												// settings
+	public static final byte RxThresholdReg = 0x18; // selects thresholds for
+													// the bit decoder
+	// public static final byte Reserved = 0x1E; // reserved for future use
+	public static final byte SerialSpeedReg = 0x1F; // selects the speed of the
+													// serial UART interface
+	public static final byte Status1Reg = 0x07; // communication status bits
+	public static final byte Status2Reg = 0x08; // receiver and transmitter
+												// status bits
+	public static final byte TCounterValReg1 = 0x2E; // shows the 16-bit timer
+														// value
+	public static final byte TCounterValReg2 = 0x2F; // shows the 16-bit timer
+														// value
+
+	public static final byte TestADCReg = 0x3B; // shows the value of ADC I and
+												// Q channels
+	// public static final byte Reserved = 0x3C; // reserved for production
+	// tests
+	// public static final byte Reserved = 0x3D; // reserved for production
+	// tests
+	// public static final byte Reserved = 0x3E; // reserved for production
+	// tests
+	// public static final byte Reserved = 0x3F; // reserved for production
+	// tests
+	public static final byte TestBusReg = 0x35; // shows the status of the
+												// internal test bus
+	public static final byte TestDAC1Reg = 0x39; // defines the test value for
+													// TestDAC1
+	public static final byte TestDAC2Reg = 0x3A; // defines the test value for
+													// TestDAC2
+	public static final byte TestPinEnReg = 0x33; // enables pin output driver
+													// on pins D1 to D7
+	public static final byte TestPinValueReg = 0x34; // defines the values for
+														// D1 to D7 when it is
+														// used as an I/O bus
+	// Page 3: Test register
+	// public static final byte Reserved = 0x30; // reserved for future use
+	public static final byte TestSel1Reg = 0x31; // general test signal
+													// configuration
+	public static final byte TestSel2Reg = 0x32; // general test signal
+													// configuration and PRBS
+													// control
+	public static final byte TModeReg = 0x2A; // defines settings for the
+												// internal timer
+	public static final byte TPrescalerReg = 0x2B; // defines settings for the
+													// internal timer
+	public static final byte TReloadRegH = 0x2C; // defines the 16-bit timer
+													// reload value
+	public static final byte TReloadRegL = 0x2D; // defines the 16-bit timer
+													// reload value
+	public static final byte TxASKReg = 0x15; // controls the setting of the
+												// transmission modulation
+
+	public static final byte TxControlReg = 0x14; // controls the logical
+													// behavior of the antenna
+													// driver pins TX1 and TX2
+	public static final byte TxModeReg = 0x12; // defines transmission data rate
+												// and framing
+
+	public static final byte TxSelReg = 0x16; // selects the internal sources
+												// for the antenna driver
+	public static final byte VersionReg = 0x37; // shows the software version
+	public static final byte WaterLevelReg = 0x0B; // level for FIFO underflow
+													// and overflow warning
+
+	public static final int MAX_LEN = 16;
+
+	public String currentID = "0000000000";
+
+	//private int clockSpeed;
+	//private int resetPin;
+	private int spiPort; // "GPIO10" MOSI, "GPIO09" MISO
+
+	MFRC522(int spiPort, int resetPin, int clockSpeed) throws DeviceInitializationException {
+		this.spiPort = spiPort;
+		//this.resetPin = resetPin;
+		//this.clockSpeed = clockSpeed;
 		
-		Gpio.pinMode(ResetPin, Gpio.OUTPUT);
-        Gpio.digitalWrite(ResetPin, Gpio.HIGH);
-        
-        Reset();
-        Write_RC522(TModeReg, (byte) 0x8D);
-        Write_RC522(TPrescalerReg, (byte) 0x3E);
-        Write_RC522(TReloadRegL, (byte) 30);
-        Write_RC522(TReloadRegH, (byte) 0);
-        Write_RC522(TxASKReg, (byte) 0x40);
-        Write_RC522(ModeReg, (byte) 0x3D);
-        Write_RC522(RFCfgReg, (byte) 0x7F);
-        AntennaOn();
-    }
-	
-	private void Reset()
-    {
-        Write_RC522(CommandReg, PCD_RESETPHASE);
-    }
-	
-	private void Write_RC522(byte address,byte value)
-    {
-		
-        byte data[] = new byte[2];
-        data[0] = (byte) ((address << 1) & 0x7E);
-        data[1] = value;
-        
-        if(Spi.wiringPiSPIDataRW(SPI_SELECT, data) == -1)
-            System.out.println("Device write  error,address="+address+",value="+value);
-    }
+		if (Spi.wiringPiSPISetup(spiPort, clockSpeed) <= -1)
+			throw new DeviceInitializationException("Error opening SPI Device");
 
-    private void AntennaOn()
-    {
-    	//byte value=Read_RC522(TxControlReg);
-        //   if((value & 0x03) != 0x03)
-        SetBitMask(TxControlReg,(byte) 0x03);
-    }
-    
-    @SuppressWarnings("unused")
-	private void AntennaOff()
-    {
-        ClearBitMask(TxControlReg,(byte) 0x03);
-    }
-    private void SetBitMask(byte address,byte mask)
-    {
-        byte value=Read_RC522(address);
-        Write_RC522(address,(byte)(value|mask));
-    }
+		Gpio.pinMode(resetPin, Gpio.OUTPUT);
+		Gpio.digitalWrite(resetPin, Gpio.HIGH);
+	}
 
-    private void ClearBitMask(byte address,byte mask)
-    {
-        byte value=Read_RC522(address);
-        Write_RC522(address,(byte)( value&(~mask)));
-    }
-
-    private byte Read_RC522(byte address)
-    {
-        byte data[]=new byte[2];
-        data[0]=(byte) (((address << 1) & 0x7E) | 0x80);
-        data[1]=0;
-        //int result=Spi.wiringPiSPIDataRW(SPI_SELECT, data);
-        //if(result == -1)
-        //    System.out.println("Device read  error,address="+address);
-        return data[1];
-    }
-	
-    public int Request(byte req_mode,int []back_bits) 
-    {
-        int status;
-        byte tagType[]=new byte[1];
-        byte data_back[]=new byte[16];
-        int backLen[]=new int[1];
-
-        Write_RC522(BitFramingReg, (byte)0x07);
-
-        tagType[0]=req_mode;
-        back_bits[0]=0;
-        status=Write_Card(PCD_TRANSCEIVE,tagType,1,data_back,back_bits,backLen);
-        if (status != MI_OK || back_bits[0] != 0x10)
-        {
-            //System.out.println("status="+status+",back_bits[0]="+back_bits[0]);
-            status = MI_ERR;
-        }
-
-        return status;
-    }
-	
-    //back_data-Length=16;
-    //back_data-
-    //back_bits-
-    //backLen-
-    private int Write_Card(byte command,byte []data,int dataLen,byte[]back_data,int[]back_bits,int[]backLen)
-    {
-        int status=MI_ERR;
-        byte irq=0,irq_wait=0,lastBits=0;
-        int n=0,i=0;
-
-        backLen[0]=0;
-        if(command == PCD_AUTHENT)
-        {
-            irq = 0x12;
-            irq_wait=0x10;
-        }
-        else if(command == PCD_TRANSCEIVE)
-        {
-            irq = 0x77;
-            irq_wait=0x30;
-        }
-
-        Write_RC522(ComlEnReg, (byte)(irq|0x80));
-        ClearBitMask(ComIrqReg, (byte)0x80);
-        SetBitMask(FIFOLevelReg, (byte)0x80);
-
-        Write_RC522(CommandReg,PCD_IDLE);
-
-        for(i=0;i<dataLen;i++)
-            Write_RC522(FIFODataReg, data[i]);
-
-        Write_RC522(CommandReg, command);
-        if(command == PCD_TRANSCEIVE)
-            SetBitMask(BitFramingReg, (byte)0x80);
-
-        i=2000;
-        while (true)
-        {
-            n = Read_RC522(ComIrqReg);
-            i--;
-            if ((i == 0) || (n & 0x01) > 0 || (n & irq_wait) > 0)
-            {
-                //System.out.println("Write_Card i="+i+",n="+n);
-                break;
-            }
-        }
-        ClearBitMask(BitFramingReg, (byte)0x80);
-
-        if(i != 0)
-        {
-            if ((Read_RC522(ErrorReg) & 0x1B)==0x00)
-            {
-                status = MI_OK;
-                if ((n & irq & 0x01) > 0)
-                    status = MI_NOTAGERR;
-                if (command == PCD_TRANSCEIVE)
-                {
-                    n = Read_RC522(FIFOLevelReg);
-                    lastBits = (byte) (Read_RC522(ControlReg) & 0x07);
-                    if (lastBits != 0)
-                        back_bits[0] = (n - 1) * 8 + lastBits;
-                    else
-                        back_bits[0] = n * 8;
-
-                    if (n == 0) n = 1;
-                    if (n > this.MAX_LEN) n = this.MAX_LEN;
-                    backLen[0] = n;
-                    for (i = 0; i < n; i++)
-                        back_data[i] = Read_RC522(FIFODataReg);
-                }
-            }
-            else
-                status = MI_ERR;
-        }
-        return  status;
-    }
-
-    //Anti-collision detection.
-    //Returns tuple of (error state, tag ID).
-    //back_data
-    public int AntiColl(byte[]back_data)
-    {
-        int status;
-        byte []serial_number = new byte[2];
-        int serial_number_check = 0;
-        int backLen[] = new int[1];
-        int back_bits[] = new int[1];
-        int i;
-
-        Write_RC522(BitFramingReg, (byte)0x00);
-        serial_number[0] = PICC_ANTICOLL;
-        serial_number[1] = 0x20;
-        status = Write_Card(PCD_TRANSCEIVE,serial_number,2,back_data,back_bits,backLen);
-        if(status == MI_OK)
-        {
-            if(backLen[0] == 5)
-            {
-                for(i=0;i<4;i++)
-                    serial_number_check ^=back_data[i];
-                if(serial_number_check != back_data[4])
-                {
-                    status = MI_ERR;
-                    System.out.println("check error");
-                }
-            }
-            else
-            {
-                status = MI_OK;
-                System.out.println("backLen[0]="+backLen[0]);
-            }
-        }
-        return status;
-    }
-    
-    public static String bytesToHex(byte[] bytes)
-	{
-		final char[] hexArray = { '0', '1', '2', '3', '4', '5', '6', '7', '8',
-				'9', 'A', 'B', 'C', 'D', 'E', 'F' };
+	public static String bytesToHex(byte[] bytes) {
+		final char[] hexArray = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 		char[] hexChars = new char[bytes.length * 2];
 		int v;
-		for (int j = 0; j < bytes.length; j++)
-		{
+		for (int j = 0; j < bytes.length; j++) {
 			v = bytes[j] & 0xFF;
 			hexChars[j * 2] = hexArray[v >>> 4];
 			hexChars[j * 2 + 1] = hexArray[v & 0x0F];
@@ -373,80 +208,254 @@ public class MFRC522 {
 		return new String(hexChars);
 	}
 
-    
-    public boolean ReadID( int sleepTime, int nbHit) throws InterruptedException{
-    
-    	// Security if user enters an unallowed number of Hit
-        if (nbHit < 1){
-        	nbHit = 3;
-        }
-        
-        // Security if user enters an unallowed sleep time
-        if (sleepTime < 100){
-        	sleepTime = 500;
-        }
-        
-        int 	back_len[] 	= new int[1];
-        byte 	tagid[] 	= new byte[5];
-        byte 	tagidVerif[]= new byte[5];
-        byte 	tagidNull[] = {0,0,0,0,0};
-        int 	hitCount 	= 0;
-        int 	notHitCount = 0;
+	// Anti-collision detection.
+	// Returns tuple of (error state, tag ID).
+	// back_data
+	public int collisionDetection(byte[] back_data) {
+		int status;
+		byte[] serial_number = new byte[2];
+		int serial_number_check = 0;
+		int backLen[] = new int[1];
+		int back_bits[] = new int[1];
+		int i;
 
-        // Read till you read "nbHit" times the same UID, then return his value
-		while (true){
-			
+		writeRegister(BitFramingReg, (byte) 0x00);
+		serial_number[0] = PICC_ANTICOLL;
+		serial_number[1] = 0x20;
+		status = writeCard(PCD_TRANSCEIVE, serial_number, 2, back_data, back_bits, backLen);
+		if (status == MI_OK) {
+			if (backLen[0] == 5) {
+				for (i = 0; i < 4; i++)
+					serial_number_check ^= back_data[i];
+				if (serial_number_check != back_data[4]) {
+					status = MI_ERR;
+					System.out.println("check error");
+				}
+			} else {
+				status = MI_OK;
+				System.out.println("backLen[0]=" + backLen[0]);
+			}
+		}
+		return status;
+	}
+
+	public void init() {
+		reset();
+		writeRegister(TModeReg, (byte) 0x8D);
+		writeRegister(TPrescalerReg, (byte) 0x3E);
+		writeRegister(TReloadRegL, (byte) 30);
+		writeRegister(TReloadRegH, (byte) 0);
+		writeRegister(TxASKReg, (byte) 0x40);
+		writeRegister(ModeReg, (byte) 0x3D);
+		writeRegister(RFCfgReg, (byte) 0x7F);
+		turnAntennaOn();
+	}
+
+	public boolean readID() throws InterruptedException {
+
+		return readID(500, 3);
+
+	}
+
+	public boolean readID(int sleepTime, int nbHit) throws InterruptedException {
+
+		// Security if user enters an unallowed number of Hit
+		if (nbHit < 1) {
+			nbHit = 3;
+		}
+
+		// Security if user enters an unallowed sleep time
+		if (sleepTime < 100) {
+			sleepTime = 500;
+		}
+
+		int back_len[] = new int[1];
+		byte tagid[] = new byte[5];
+		byte tagidVerif[] = new byte[5];
+		byte tagidNull[] = { 0, 0, 0, 0, 0 };
+		int hitCount = 0;
+		int notHitCount = 0;
+
+		// Read till you read "nbHit" times the same UID, then return his value
+		while (true) {
+
 			// Verify if there's a card to read
-		    if(this.Request(PICC_REQIDL, back_len) == MI_OK){
-		    	//System.out.println("Detected card:");
-		    }
-		
-		    // Verify if there's a collision with the signal to read
-		    if(this.AntiColl(tagid) != MI_OK)
-		    { 
-		        notHitCount++;
-		        if (notHitCount>nbHit){
-		        	// If it's been a bad read more than nbHit times in a row, 
-		        	// reset the count and the UID stored
-		        	//System.out.println("Error, card is not detected");
-		        	currentID = bytesToHex(tagidNull);
-		        	return false;
-		        }
-		        continue;
-		    }
-		    
-		    // Initialisation of the verification ID tag (tagidVerif)
-		    if (tagidVerif == tagidNull){
-		    	tagidVerif = tagid;
-		    	hitCount = 0;
-		    	notHitCount = 0;
-		    }
-		    
-		    // The right id is read
-		    if (tagidVerif == tagid){
-		    	hitCount++ ;
-		    	notHitCount = 0;
-		    }
-		    
-		    // The wrong id is read
-		    if (tagidVerif != tagid){
-		    	hitCount = 0;
-		    }
-		    
-		    if (hitCount == nbHit){
-		    	currentID = bytesToHex(tagid);
-		    	return true;
-		    }
-		    
-		    // Insert a timer to read the RFID card at a reasonable rate
-				Thread.sleep(sleepTime);
-				    
+			if (this.request(PICC_REQIDL, back_len) == MI_OK) {
+				// System.out.println("Detected card:");
+			}
+
+			// Verify if there's a collision with the signal to read
+			if (this.collisionDetection(tagid) != MI_OK) {
+				notHitCount++;
+				if (notHitCount > nbHit) {
+					// If it's been a bad read more than nbHit times in a row,
+					// reset the count and the UID stored
+					// System.out.println("Error, card is not detected");
+					currentID = bytesToHex(tagidNull);
+					return false;
+				}
+				continue;
+			}
+
+			// Initialisation of the verification ID tag (tagidVerif)
+			if (tagidVerif == tagidNull) {
+				tagidVerif = tagid;
+				hitCount = 0;
+				notHitCount = 0;
+			}
+
+			// The right id is read
+			if (tagidVerif == tagid) {
+				hitCount++;
+				notHitCount = 0;
+			}
+
+			// The wrong id is read
+			if (tagidVerif != tagid) {
+				hitCount = 0;
+			}
+
+			if (hitCount == nbHit) {
+				currentID = bytesToHex(tagid);
+				return true;
+			}
+
+			// Insert a timer to read the RFID card at a reasonable rate
+			Thread.sleep(sleepTime);
+
 		}
 	}
-    
-    public boolean ReadID() throws InterruptedException{
-    	
-    	return ReadID(500, 3);
-	
+
+	public int request(byte req_mode, int[] back_bits) {
+		int status;
+		byte tagType[] = new byte[1];
+		byte data_back[] = new byte[16];
+		int backLen[] = new int[1];
+
+		writeRegister(BitFramingReg, (byte) 0x07);
+
+		tagType[0] = req_mode;
+		back_bits[0] = 0;
+		status = writeCard(PCD_TRANSCEIVE, tagType, 1, data_back, back_bits, backLen);
+		if (status != MI_OK || back_bits[0] != 0x10) {
+			// System.out.println("status="+status+",back_bits[0]="+back_bits[0]);
+			status = MI_ERR;
+		}
+
+		return status;
+	}
+
+	private void clearBitMask(byte address, byte mask) {
+		byte value = readRegister(address);
+		writeRegister(address, (byte) (value & (~mask)));
+	}
+
+	private byte readRegister(byte address) {
+		byte data[] = new byte[2];
+		data[0] = (byte) (((address << 1) & 0x7E) | 0x80);
+		data[1] = 0;
+		// int result=Spi.wiringPiSPIDataRW(SPI_SELECT, data);
+		// if(result == -1)
+		// System.out.println("Device read error,address="+address);
+		return data[1];
+	}
+
+	private void reset() {
+		writeRegister(CommandReg, PCD_RESETPHASE);
+	}
+
+	private void setBitMask(byte address, byte mask) {
+		byte value = readRegister(address);
+		writeRegister(address, (byte) (value | mask));
+	}
+
+	@SuppressWarnings("unused")
+	private void turnAntennaOff() {
+		clearBitMask(TxControlReg, (byte) 0x03);
+	}
+
+	private void turnAntennaOn() {
+		// byte value=Read_RC522(TxControlReg);
+		// if((value & 0x03) != 0x03)
+		setBitMask(TxControlReg, (byte) 0x03);
+	}
+
+	// back_data-Length=16;
+	// back_data-
+	// back_bits-
+	// backLen-
+	private int writeCard(byte command, byte[] data, int dataLen, byte[] back_data, int[] back_bits, int[] backLen) {
+		int status = MI_ERR;
+		byte irq = 0, irq_wait = 0, lastBits = 0;
+		int n = 0, i = 0;
+
+		backLen[0] = 0;
+		if (command == PCD_AUTHENT) {
+			irq = 0x12;
+			irq_wait = 0x10;
+		} else if (command == PCD_TRANSCEIVE) {
+			irq = 0x77;
+			irq_wait = 0x30;
+		}
+
+		writeRegister(ComlEnReg, (byte) (irq | 0x80));
+		clearBitMask(ComIrqReg, (byte) 0x80);
+		setBitMask(FIFOLevelReg, (byte) 0x80);
+
+		writeRegister(CommandReg, PCD_IDLE);
+
+		for (i = 0; i < dataLen; i++)
+			writeRegister(FIFODataReg, data[i]);
+
+		writeRegister(CommandReg, command);
+		if (command == PCD_TRANSCEIVE)
+			setBitMask(BitFramingReg, (byte) 0x80);
+
+		i = 2000;
+		while (true) {
+			n = readRegister(ComIrqReg);
+			i--;
+			if ((i == 0) || (n & 0x01) > 0 || (n & irq_wait) > 0) {
+				// System.out.println("Write_Card i="+i+",n="+n);
+				break;
+			}
+		}
+		clearBitMask(BitFramingReg, (byte) 0x80);
+
+		if (i != 0) {
+			if ((readRegister(ErrorReg) & 0x1B) == 0x00) {
+				status = MI_OK;
+				if ((n & irq & 0x01) > 0)
+					status = MI_NOTAGERR;
+				if (command == PCD_TRANSCEIVE) {
+					n = readRegister(FIFOLevelReg);
+					lastBits = (byte) (readRegister(ControlReg) & 0x07);
+					if (lastBits != 0)
+						back_bits[0] = (n - 1) * 8 + lastBits;
+					else
+						back_bits[0] = n * 8;
+
+					if (n == 0)
+						n = 1;
+					if (n > MAX_LEN)
+						n = MAX_LEN;
+					backLen[0] = n;
+					for (i = 0; i < n; i++)
+						back_data[i] = readRegister(FIFODataReg);
+				}
+			} else
+				status = MI_ERR;
+		}
+		return status;
+	}
+
+	private void writeRegister(byte address, byte value) {
+
+		byte data[] = new byte[2];
+		data[0] = (byte) ((address << 1) & 0x7E);
+		data[1] = value;
+
+		if (Spi.wiringPiSPIDataRW(spiPort, data) == -1)
+			System.out.println("Device write  error,address=" + address + ",value=" + value);
 	}
 }

--- a/Backend/src/org/teamneko/schrodinger/backend/RC522/Pi4JMissingException.java
+++ b/Backend/src/org/teamneko/schrodinger/backend/RC522/Pi4JMissingException.java
@@ -1,0 +1,27 @@
+package org.teamneko.schrodinger.backend.RC522;
+
+public class Pi4JMissingException extends Exception {
+	private static final long serialVersionUID = 2342413638469372491L;
+
+	public Pi4JMissingException() {
+		super();
+	}
+
+	public Pi4JMissingException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public Pi4JMissingException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public Pi4JMissingException(String message) {
+		super(message);
+	}
+
+	public Pi4JMissingException(Throwable cause) {
+		super(cause);
+	}
+	
+}

--- a/Backend/src/org/teamneko/schrodinger/backend/RC522/RFIDFactory.java
+++ b/Backend/src/org/teamneko/schrodinger/backend/RC522/RFIDFactory.java
@@ -1,0 +1,51 @@
+package org.teamneko.schrodinger.backend.RC522;
+
+import com.pi4j.wiringpi.Gpio;
+
+public class RFIDFactory {
+	private static boolean pi4jSetUp = false;
+	private static boolean pi4jMissing = false;
+
+	private static final int DEFAULT_SPI_PORT = 500000;
+	private static final int DEFAULT_CLOCK_SPEED = 500000;
+	private static final int DEFAULT_RESET_PIN = 22;
+	
+	public static MFRC522 createMFRC522() throws Pi4JMissingException, DeviceInitializationException {
+		return createMFRC522(DEFAULT_SPI_PORT, DEFAULT_RESET_PIN, DEFAULT_CLOCK_SPEED);
+	}
+	
+	public static MFRC522 createMFRC522(int spiPort) throws Pi4JMissingException, DeviceInitializationException {
+		return createMFRC522(spiPort, DEFAULT_RESET_PIN, DEFAULT_CLOCK_SPEED);
+	}
+	
+	public static MFRC522 createMFRC522(int spiPort, int resetPin) throws Pi4JMissingException, DeviceInitializationException {
+		return createMFRC522(spiPort, resetPin, DEFAULT_CLOCK_SPEED);
+	}
+	
+	public static MFRC522 createMFRC522(int spiPort, int resetPin, int clockSpeed) throws Pi4JMissingException, DeviceInitializationException {
+		MFRC522 instance;
+		
+		//Setup Pi4J if neccessary
+		if (!pi4jSetUp)
+			setupPi4j();
+		
+		//If Pi4J is not available, throw exception
+		if(pi4jMissing)
+			throw new Pi4JMissingException();
+		
+		instance = new MFRC522(spiPort, resetPin, clockSpeed);
+		instance.init();
+		return instance;
+	}
+	
+	private static void setupPi4j() {
+		pi4jSetUp = true;
+		
+		try {
+			Gpio.wiringPiSetup();           //Enabling wiringPi pin schema
+		} catch(UnsatisfiedLinkError e) {
+			pi4jMissing = true;
+		}
+		
+	}
+}

--- a/Backend/src/org/teamneko/schrodinger/backend/RC522/test.java
+++ b/Backend/src/org/teamneko/schrodinger/backend/RC522/test.java
@@ -2,14 +2,22 @@ package org.teamneko.schrodinger.backend.RC522;
 
 public class test {
 
-	public static void main(String args[]) throws InterruptedException
+	public static void main(String args[]) throws InterruptedException, DeviceInitializationException
     {
-		
-	        MFRC522 rc522=new MFRC522();
+	    MFRC522 rfid;
+		try {
+			rfid = RFIDFactory.createMFRC522();
+		} catch (Pi4JMissingException e) {
+			System.out.println("Error 314: Could not open Pi4j");
+			System.out.println("This probably means you are not running on a Pi");
+			System.out.println("If you are running on a Pi, this probably means Pi4J is improperly configured");
+			System.exit(1);
+			return;
+		}
 	        
-	    while (true){    
-	    	if (rc522.ReadID());
-	    	System.out.println("Detecte card: "+ MFRC522.currentID);
+	    while (true){
+	    	if (rfid.readID());
+	    	System.out.println("Detecte card: "+ rfid.currentID);
 	    }
 	
     };


### PR DESCRIPTION
Formattage et réorganisation des éléments dans MFRC522.
Déplacement de l'initialisation du SPI dans le constructeur.
Création des classes d'exception Pi4JNotFound et DeviceInitialization.
Le factory détecte Pi4J à l'avance lance une exception Pi4JNotFound quand Pi4J n'est pas disponible.
Le constructeur de MFRC522 lance une DeviceInitializationException si erreur lors de l'initalisation du SPI.
Le MFRC522 n'est construit que si celui-ci est fonctionnel.
currentId est une variable membre de l'objet et non plus statique comme avant
Fiou. Ca fait pas mal le tour. Et c'est pas fini.